### PR TITLE
youtube: Normalize timestamps to seconds

### DIFF
--- a/src/features/clips/providers/youtube/youtube.test.ts
+++ b/src/features/clips/providers/youtube/youtube.test.ts
@@ -17,6 +17,10 @@ describe('youtubeProvider', () => {
     expect(youtubeProvider.getIdFromUrl('https://www.youtube.com/watch?v=1TewCPi92ro&t=30')).toEqual('1TewCPi92ro;30');
   });
 
+  it('gets clip info from www.youtube.com url with timestamp in hours/minutes/seconds', () => {
+    expect(youtubeProvider.getIdFromUrl('https://www.youtube.com/watch?v=1TewCPi92ro&t=1m42s1h')).toEqual('1TewCPi92ro;3702');
+  });
+
   it('gets clip info from youtu.be url', () => {
     expect(youtubeProvider.getIdFromUrl('https://youtu.be/1TewCPi92ro')).toEqual('1TewCPi92ro');
   });

--- a/src/features/clips/providers/youtube/youtubeProvider.ts
+++ b/src/features/clips/providers/youtube/youtubeProvider.ts
@@ -28,7 +28,30 @@ class YoutubeProvider implements ClipProvider {
     const startTime = uri.searchParams.get('t') ?? undefined;
 
     if (startTime) {
-      return `${id};${startTime}`;
+      const chunks = startTime.split(/([hms])/).filter(chunk => chunk !== '');
+      const magnitudes = chunks.filter(chunk => chunk.match(/[0-9]+/)).map(chunk => parseInt(chunk));
+      const UNITS = ['h', 'm', 's'];
+      const seenUnits = chunks.filter(chunk => UNITS.includes(chunk));
+
+      if (chunks.length === 1) {
+        return `${id};${chunks[0]}`;
+      } else {
+        const normalizedStartTime = magnitudes.reduce((accum, magnitude, index) => {
+          let conversionFactor = 0;
+
+          if (seenUnits[index] === 'h') {
+            conversionFactor = 3600;
+          } else if (seenUnits[index] === 'm') {
+            conversionFactor = 60;
+          } else if (seenUnits[index] === 's') {
+            conversionFactor = 1;
+          }
+
+          return accum + magnitude * conversionFactor;
+        }, 0);
+
+        return `${id};${normalizedStartTime}`;
+      }
     } else {
       return id;
     }


### PR DESCRIPTION
This attempts to fix a problem where enqueuing https://www.youtube.com/watch?v=6zY89ZLDZVo&t=5s will start at the beginning of the video rather than at the specified timestamp.

However, I do not know how to test because of a problem I encountered, described in https://github.com/JakeMiki/twitch-clip-queue/issues/11.