### PR TITLE
feat: Added New HostName for Kick.com Clips

### DIFF
--- a/src/features/clips/providers/kickClip/kickClipProvider.ts
+++ b/src/features/clips/providers/kickClip/kickClipProvider.ts
@@ -7,9 +7,10 @@ class KickClipProvider implements ClipProvider {
   private clipCache: Map<string, string> = new Map();
 
   getIdFromUrl(url: string): string | undefined {
+    const KICK_WHITELISTED_HOSTNAMES = ['kick.com', 'www.kick.com', 'clkick.com'];
     try {
       const uri = new URL(url);
-      if (uri.hostname === 'kick.com' || uri.hostname === 'www.kick.com') {
+      if (KICK_WHITELISTED_HOSTNAMES.includes(uri.hostname)) {
         const id = uri.searchParams.get('clip');
         if (id) {
           return id;


### PR DESCRIPTION
- So for Kick Clips People put clkick.com like this https://clkick.com/{channel}/clips/{id} because it previews the thumbnails for the Clip in discords Channels so i added it as a Whitelisted Hostname so it can go into the queue if user sends the clips with Cl in them.